### PR TITLE
Bug 1194767 - use slugid.nice() instead of slugid.v4()

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "octokit": "0.10.2",
     "promise": "~4.0.0",
     "proxied-promise-object": "~0.1.0",
-    "slugid": "^1.0.2",
+    "slugid": "^1.1.0",
     "superagent-promise": "^0.1.0",
     "taskcluster-base": "^0.4.6",
     "taskcluster-client": "^0.15.6",

--- a/routes/github_pr.js
+++ b/routes/github_pr.js
@@ -164,7 +164,7 @@ module.exports = function(runtime) {
 
     // finally use the factory to fill in any required fields that have
     // defaults...
-    var id = slugid.v4();
+    var id = slugid.nice();
     runtime.log('create graph', { id: id, graph: graph });
 
     try {

--- a/routes/github_push.js
+++ b/routes/github_push.js
@@ -154,7 +154,7 @@ module.exports = function(runtime) {
       return task.taskId;
     });
 
-    var id = slugid.v4();
+    var id = slugid.nice();
     runtime.log('create graph', { id: id, graph: graph });
 
     var graphStatus =


### PR DESCRIPTION
I ran the unit tests, but not the integration tests. We don't have a CI set up for gaia-taskcluster changes, as far as I can see - I'm not sure we should invest in that at this point - we should probably port over to taskcluster-github at some point to reduce the number of systems.
