### PR TITLE
Bug 1218928: remove route scopes from `task.scopes`

### DIFF
--- a/routes/github_push.js
+++ b/routes/github_push.js
@@ -136,7 +136,6 @@ module.exports = function(runtime) {
 
       // Gaia scopes.
       task.task.routes.push(runtime.route);
-      task.task.scopes.push('queue:route:' + runtime.route);
 
       // Treeherder
       var treeherderRoute = runtime.taskclusterTreeherder.route + '.' +
@@ -144,7 +143,6 @@ module.exports = function(runtime) {
                             commit;
 
       task.task.routes.push(treeherderRoute);
-      task.task.scopes.push('queue:route:' + treeherderRoute);
 
       return task;
     });


### PR DESCRIPTION
Tasks don't need route scopes -- the thing calling `queue.defineTask`
does (in this case, the scheduler, using `taskgraph.scopes`)

This matches github_pr.js, which seems to work fine with no scopes.  The error was because `taskgraph.scopes` didn't satisfy `["tc-taskcluster.gaia.<revision>"].
